### PR TITLE
Add more peer info fields

### DIFF
--- a/crates/quilclient/CHANGELOG.md
+++ b/crates/quilclient/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `timestamp` and `version` columns to `peer-info` output.
+
 ### Fixed
 
 ### Changed

--- a/crates/quilclient/src/csv_helpers.rs
+++ b/crates/quilclient/src/csv_helpers.rs
@@ -32,11 +32,16 @@ pub fn peer_infos_to_rows(peer_infos: impl IntoIterator<Item = PeerInfo>) -> Vec
                 peer_id,
                 multiaddrs,
                 max_frame,
+                timestamp,
+                version,
+                ..
             } = peer_info;
             multiaddrs.into_iter().map(move |multiaddr| PeerInfoRow {
                 peer_id,
                 multiaddr,
                 max_frame,
+                version: display_version(&version),
+                timestamp: timestamp.to_string(),
             })
         })
         .collect()
@@ -89,4 +94,10 @@ pub struct PeerInfoRow {
     pub peer_id: PeerId,
     pub multiaddr: multiaddr::Multiaddr,
     pub max_frame: u64,
+    pub version: String,
+    pub timestamp: String,
+}
+
+fn display_version(version: &[u8; 3]) -> String {
+    format!("{}.{}.{}", version[0], version[1], version[2])
 }

--- a/crates/quilibrium/CHANGELOG.md
+++ b/crates/quilibrium/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Expose [QuilTokenError](https://docs.rs/quilibrium/latest/quilibrium/enum.QuilTokenError.html) in the public interface.
+- Exposed [QuilTokenError](https://docs.rs/quilibrium/latest/quilibrium/oblivious_transfer_units/enum.QuilTokenError.html) in the public interface.
+- Added `timestamp`, `version`, `public_key`, `signature` fields to [PeerInfo](https://docs.rs/quilibrium/latest/quilibrium/node/struct.PeerInfo.html).
 
 ### Fixed
 
@@ -29,9 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added [frame metadata](https://docs.rs/quilibrium/0.2.0/quilibrium/struct.NodeClient.html#method.frames) query support to `NodeClient`.
-- Added [frame info](https://docs.rs/quilibrium/0.2.0/quilibrium/struct.NodeClient.html#method.frame_info) support to `NodeClient`.
-- Added [token info](https://docs.rs/quilibrium/0.2.0/quilibrium/struct.NodeClient.html#method.token_info) support to `NodeClient`.
+- Added [frame metadata](https://docs.rs/quilibrium/0.2.0/quilibrium/node/struct.NodeClient.html#method.frames) query support to `NodeClient`.
+- Added [frame info](https://docs.rs/quilibrium/0.2.0/quilibrium/node/struct.NodeClient.html#method.frame_info) support to `NodeClient`.
+- Added [token info](https://docs.rs/quilibrium/0.2.0/quilibrium/node/struct.NodeClient.html#method.token_info) support to `NodeClient`.
 
 ### Changed
 

--- a/crates/quilibrium/README.md
+++ b/crates/quilibrium/README.md
@@ -6,7 +6,7 @@
 
 ## Example usage
 
-```rust
+```rust, no_compile
 // Import the client
 use quilibrium::NodeClient;
 


### PR DESCRIPTION
- Added `timestamp`, `version`, `public_key`, `signature` fields to [PeerInfo](https://docs.rs/quilibrium/latest/quilibrium/node/struct.PeerInfo.html) in the client library.
- Added `timestamp` and `version` columns to `peer-info` output in `quilclient`.