### PR TITLE
Add support for fetching peer manifests

### DIFF
--- a/crates/quilclient/CHANGELOG.md
+++ b/crates/quilclient/CHANGELOG.md
@@ -3,11 +3,15 @@
 All notable changes to this crate will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Added
+
+- Added CLI support for fetching self-reported peer manifests and printing them
+  to stdout as CSV.
 
 ### Fixed
 
@@ -25,19 +29,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added CLI support for fetching frame metadata and printing it in CSV format to stdout.
+- Added CLI support for fetching frame metadata and printing it in CSV format to
+  stdout.
 - Added CLI support to download a clock frame in Protocol Buffer format.
-- Added CLI support to fetch the token balance of the node and print it to stdout in QUIL units as an integer.
-- Added CLI support to fetch the confirmed token supply and print it to stdout in QUIL units as an integer. 
+- Added CLI support to fetch the token balance of the node and print it to
+  stdout in QUIL units as an integer.
+- Added CLI support to fetch the confirmed token supply and print it to stdout
+  in QUIL units as an integer.
 
 ## [0.1.0] - 2023-10-14
 
 ### Added
 
-- Added CLI support to fetch the peers from the node's peer store and print them to stdout as CSV.
-- Added CLI support to fetch the broadcasted sync info that gets replicated through the network mesh and print it to stdout as CSV. 
+- Added CLI support to fetch the peers from the node's peer store and print them
+  to stdout as CSV.
+- Added CLI support to fetch the broadcasted sync info that gets replicated
+  through the network mesh and print it to stdout as CSV.
 
 [unreleased]: https://github.com/agostbiro/quilibrium-rs/compare/quilclient-0.2.0..HEAD
+
 [0.2.1]: https://github.com/agostbiro/quilibrium-rs/compare/quilclient-0.2.0..quilclient-0.2.1
+
 [0.2.0]: https://github.com/agostbiro/quilibrium-rs/compare/quilclient-0.1.0..quilclient-0.2.0
+
 [0.1.0]: https://github.com/agostbiro/quilibrium-rs/compare/quilclient-0.1.0

--- a/crates/quilclient/src/main.rs
+++ b/crates/quilclient/src/main.rs
@@ -71,6 +71,8 @@ enum Command {
         #[clap(value_enum, default_value_t=PeerType::Cooperative)]
         peer_type: PeerType,
     },
+    /// Fetch the self-reported peer manifests that the node knows about and print them to stdout as CSV.
+    PeerManifests,
     /// Fetch the token balance of the node and print it to stdout in QUIL units as an integer.
     TokenBalance,
     /// Fetch the confirmed token supply and print it to stdout in QUIL units as an integer.
@@ -165,6 +167,10 @@ async fn main() -> Result<()> {
                 PeerType::Cooperative => write_peer_infos(peer_info.peers).await?,
                 PeerType::Uncooperative => write_peer_infos(peer_info.uncooperative_peers).await?,
             };
+        }
+        Command::PeerManifests => {
+            let response = client.peer_manifests().await?;
+            write_csv_to_stdout(response.peer_manifests).await?;
         }
         Command::TokenBalance => {
             let token_info = client.token_info().await?;

--- a/crates/quilibrium/CHANGELOG.md
+++ b/crates/quilibrium/CHANGELOG.md
@@ -3,11 +3,14 @@
 All notable changes to this crate will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Added
+
+- Added support for fetching self-reported peer manifests from a node via gRPC.
 
 ### Fixed
 
@@ -19,8 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Exposed [QuilTokenError](https://docs.rs/quilibrium/latest/quilibrium/oblivious_transfer_units/enum.QuilTokenError.html) in the public interface.
-- Added `timestamp`, `version`, `public_key`, `signature` fields to [PeerInfo](https://docs.rs/quilibrium/latest/quilibrium/node/struct.PeerInfo.html).
+-
+Exposed [QuilTokenError](https://docs.rs/quilibrium/latest/quilibrium/oblivious_transfer_units/enum.QuilTokenError.html)
+in the public interface.
+- Added `timestamp`, `version`, `public_key`, `signature` fields
+  to [PeerInfo](https://docs.rs/quilibrium/latest/quilibrium/node/struct.PeerInfo.html).
 
 ### Changed
 
@@ -32,37 +38,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [ObliviousTransferUnits](https://docs.rs/quilibrium/latest/quilibrium/struct.ObliviousTransferUnits.html)
   from a longer slice was already an error.
 
-
 ## [0.2.0] - 2023-10-29
 
 ### Added
 
-- Added [frame metadata](https://docs.rs/quilibrium/0.2.0/quilibrium/node/struct.NodeClient.html#method.frames) query support to `NodeClient`.
-- Added [frame info](https://docs.rs/quilibrium/0.2.0/quilibrium/node/struct.NodeClient.html#method.frame_info) support to `NodeClient`.
-- Added [token info](https://docs.rs/quilibrium/0.2.0/quilibrium/node/struct.NodeClient.html#method.token_info) support to `NodeClient`.
+-
+Added [frame metadata](https://docs.rs/quilibrium/0.2.0/quilibrium/node/struct.NodeClient.html#method.frames)
+query support to `NodeClient`.
+-
+Added [frame info](https://docs.rs/quilibrium/0.2.0/quilibrium/node/struct.NodeClient.html#method.frame_info)
+support to `NodeClient`.
+-
+Added [token info](https://docs.rs/quilibrium/0.2.0/quilibrium/node/struct.NodeClient.html#method.token_info)
+support to `NodeClient`.
 
 ### Changed
 
-- Node related types are now exposed in the `node` module (as opposed to the library root).
+- Node related types are now exposed in the `node` module (as opposed to the
+  library root).
 
 ### Removed
 
-- Removed the `csv` module and moved it to the [quilclient](../quilclient/README.md) crate as a private module as it was tightly coupled with that crate.
+- Removed the `csv` module and moved it to
+  the [quilclient](../quilclient/README.md) crate as a private module as it was
+  tightly coupled with that crate.
 
 ## [0.1.1] - 2023-10-14
 
 ### Fixed
 
-- Add missing debug and clone implementations to `NodeClient` and `NetworkInfoResponse`.
+- Add missing debug and clone implementations to `NodeClient`
+  and `NetworkInfoResponse`.
 
 ## [0.1.0] - 2023-10-14
 
 ### Added
 
-- Added `NodeClient` with [network info](https://docs.rs/quilibrium/0.1.0/quilibrium/struct.NodeClient.html#method.network_info) and [peer info](https://docs.rs/quilibrium/0.1.0/quilibrium/struct.NodeClient.html#method.peer_info) support.
+- Added `NodeClient`
+  with [network info](https://docs.rs/quilibrium/0.1.0/quilibrium/struct.NodeClient.html#method.network_info)
+  and [peer info](https://docs.rs/quilibrium/0.1.0/quilibrium/struct.NodeClient.html#method.peer_info)
+  support.
 
 [unreleased]: https://github.com/agostbiro/quilibrium-rs/compare/quilibrium-0.2.0..HEAD
+
 [0.2.1]: https://github.com/agostbiro/quilibrium-rs/compare/quilibrium-0.2.0..quilibrium-0.2.1
+
 [0.2.0]: https://github.com/agostbiro/quilibrium-rs/compare/quilibrium-0.1.1..quilibrium-0.2.0
+
 [0.1.1]: https://github.com/agostbiro/quilibrium-rs/compare/quilibrium-0.1.0..quilibrium-0.1.1
+
 [0.1.0]: https://github.com/agostbiro/quilibrium-rs/compare/quilibrium-0.1.0


### PR DESCRIPTION
- Add support to the client library for fetching self-reported peer manifests from a node via gRPC.
- Add CLI support for fetching self-reported peer manifests and printing them to stdout as CSV.

Closes https://github.com/agostbiro/quilibrium-rs/issues/17