### PR TITLE
Update rustc to 1.74

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.74.0"
 components = [ "rustfmt", "clippy" ]
-


### PR DESCRIPTION
`clap v4.5.4` needs rustc 1.74 or newer